### PR TITLE
Always send `filter` - send empty map if it has no fields or is absent

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -172,8 +172,16 @@ resource "aws_s3_bucket" "this" {
             }
           }
 
+          # Send empty map if `filter` is an empty map or absent entirely
           dynamic "filter" {
-            for_each = length(keys(lookup(rules.value, "filter", {}))) == 0 ? [] : [lookup(rules.value, "filter", {})]
+            for_each = length(keys(lookup(rules.value, "filter", {}))) == 0 ? [{}] : []
+
+            content {}
+          }
+
+          # Send `filter` if it is present and has at least one field
+          dynamic "filter" {
+            for_each = length(keys(lookup(rules.value, "filter", {}))) != 0 ? [lookup(rules.value, "filter", {})] : []
 
             content {
               prefix = lookup(filter.value, "prefix", null)


### PR DESCRIPTION
See this [terraform-provider-aws](https://github.com/hashicorp/terraform-provider-aws/issues/16546) issue for additional context. In the absence of at least an empty `filter` map if no filter was specified, `terraform apply`  gives the following error for multi-destination S3 replication rules.

`Number of distinct destination bucket ARNs cannot exceed 1`